### PR TITLE
feat: add scroll turning pages in single page mode & fix vertical sroll

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,1 +1,0 @@
-feat: Implement swipe to navigate in single page mode

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,1 @@
+feat: Implement swipe to navigate in single page mode

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "husky"
   },
   "engines": {
-    "node": "22.12.0"
+    "node": ">=22.12.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": "eslint --fix"

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -995,6 +995,7 @@
         "skip_dup_chapters": "Skip duplicate chapters",
         "skip_filtered_chapters": "Skip filtered chapters",
         "static_navigation": "Static navigation",
+        "swipe_preview_threshold": "Swipe preview threshold",
         "unchangeable_in_reader": "Setting can not be changed while the reader is opened"
       },
       "overlay_mode": "Overlay mode",

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -817,6 +817,7 @@
                 "reading_mode": "阅读模式",
                 "custom_scroll_amount": "自定义滚动距离",
                 "skip_filtered_chapters": "跳过已过滤的章节",
+                "swipe_preview_threshold": "滑动预览阈值",
                 "unchangeable_in_reader": "在阅读器打开时无法更改设置"
             },
             "reader_type": {

--- a/src/lib/requests/client/BaseClient.ts
+++ b/src/lib/requests/client/BaseClient.ts
@@ -17,7 +17,12 @@ export abstract class BaseClient<Client, ClientConfig, Fetcher> {
         const { hostname, port, protocol } = window.location;
 
         // if port is 3000 it's probably running from webpack development server
-        const inferredPort = import.meta.env.DEV && port === '3000' ? '4567' : port;
+        // return empty string to use relative URLs and go through Vite proxy
+        if (import.meta.env.DEV && port === '3000') {
+            return '';
+        }
+
+        const inferredPort = port;
         return AppStorage.local.getItemParsed('serverBaseURL', `${protocol}//${hostname}:${inferredPort}`);
     }
 

--- a/src/modules/metadata/Metadata.constants.ts
+++ b/src/modules/metadata/Metadata.constants.ts
@@ -24,6 +24,7 @@ import {
     PAGE_GAP,
     PROGRESS_BAR_SIZE,
     SCROLL_AMOUNT,
+    SWIPE_PREVIEW_THRESHOLD,
 } from '@/modules/reader/constants/ReaderSettings.constants.tsx';
 import { coerceIn, jsonSaveParse } from '@/lib/HelperFunctions.ts';
 import { DOWNLOAD_AHEAD } from '@/modules/downloads/Downloads.constants.ts';
@@ -377,7 +378,8 @@ export const APP_METADATA: Record<
     },
     swipePreviewThreshold: {
         convert: convertToNumber,
-        toConstrainedValue: (value: number) => coerceIn(value, 10, 50),
+        toConstrainedValue: (value: number) =>
+            coerceIn(value, SWIPE_PREVIEW_THRESHOLD.min, SWIPE_PREVIEW_THRESHOLD.max),
     },
 } as const;
 

--- a/src/modules/metadata/Metadata.constants.ts
+++ b/src/modules/metadata/Metadata.constants.ts
@@ -375,6 +375,10 @@ export const APP_METADATA: Record<
     excludedScanlators: {
         convert: convertToObject<string[]>,
     },
+    swipePreviewThreshold: {
+        convert: convertToNumber,
+        toConstrainedValue: (value: number) => coerceIn(value, 10, 50),
+    },
 } as const;
 
 export const VALID_APP_METADATA_KEYS = Object.keys(APP_METADATA);

--- a/src/modules/reader/components/settings/layout/ReaderLayoutSettings.tsx
+++ b/src/modules/reader/components/settings/layout/ReaderLayoutSettings.tsx
@@ -19,6 +19,7 @@ import { ReaderSettingStretchPage } from '@/modules/reader/components/settings/l
 import { ReaderSettingsTypeProps } from '@/modules/reader/types/Reader.types.ts';
 import { ReaderSettingPageGap } from '@/modules/reader/components/settings/layout/ReaderSettingPageGap.tsx';
 import { ReaderSettingWidth } from '@/modules/reader/components/settings/layout/ReaderSettingWidth.tsx';
+import { ReaderSettingSwipePreviewThreshold } from '@/modules/reader/components/settings/layout/ReaderSettingSwipePreviewThreshold.tsx';
 import { DefaultSettingFootnote } from '@/modules/reader/components/settings/DefaultSettingFootnote.tsx';
 import { TReaderTapZoneContext } from '@/modules/reader/types/TapZoneLayout.types.ts';
 import { ReaderDefaultLayoutSettings } from '@/modules/reader/components/settings/layout/ReaderDefaultLayoutSettings.tsx';
@@ -87,6 +88,13 @@ export const ReaderLayoutSettings = ({
                     setShowPreview(true);
                     onDefault?.('tapZoneInvertMode');
                 }}
+            />
+            <ReaderSettingSwipePreviewThreshold
+                swipePreviewThreshold={settings.swipePreviewThreshold}
+                readingMode={settings.readingMode}
+                isDefaultable={isDefaultable}
+                onDefault={() => onDefault?.('swipePreviewThreshold')}
+                updateSetting={(...args) => updateSetting('swipePreviewThreshold', ...args)}
             />
             <ReaderSettingPageScaleMode
                 pageScaleMode={settings.pageScaleMode}

--- a/src/modules/reader/components/settings/layout/ReaderSettingSwipePreviewThreshold.tsx
+++ b/src/modules/reader/components/settings/layout/ReaderSettingSwipePreviewThreshold.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { IReaderSettings, IReaderSettingsWithDefaultFlag, ReadingMode } from '@/modules/reader/types/Reader.types.ts';
+import { SliderInput } from '@/modules/core/components/inputs/SliderInput.tsx';
+import {
+    DEFAULT_READER_SETTINGS,
+    SWIPE_PREVIEW_THRESHOLD,
+} from '@/modules/reader/constants/ReaderSettings.constants.tsx';
+import { MultiValueButtonDefaultableProps } from '@/modules/core/Core.types.ts';
+
+export const ReaderSettingSwipePreviewThreshold = ({
+    swipePreviewThreshold,
+    readingMode,
+    isDefaultable,
+    onDefault,
+    updateSetting,
+}: Pick<IReaderSettingsWithDefaultFlag, 'swipePreviewThreshold' | 'readingMode'> &
+    Pick<MultiValueButtonDefaultableProps<IReaderSettings['swipePreviewThreshold']>, 'isDefaultable' | 'onDefault'> & {
+        updateSetting: (threshold: number, commit: boolean) => void;
+    }) => {
+    const { t } = useTranslation();
+
+    // 只在单页阅读模式下显示此设置
+    const isChangeable = readingMode.value === ReadingMode.SINGLE_PAGE;
+    if (!isChangeable) {
+        return null;
+    }
+
+    return (
+        <SliderInput
+            label={t('reader.settings.label.swipe_preview_threshold')}
+            value={t('global.value', { value: swipePreviewThreshold.value, unit: '%' })}
+            onDefault={isDefaultable ? onDefault : undefined}
+            slotProps={{
+                slider: {
+                    defaultValue: DEFAULT_READER_SETTINGS.swipePreviewThreshold,
+                    value: swipePreviewThreshold.value,
+                    step: SWIPE_PREVIEW_THRESHOLD.step,
+                    min: SWIPE_PREVIEW_THRESHOLD.min,
+                    max: SWIPE_PREVIEW_THRESHOLD.max,
+                    onChange: (_, value) => {
+                        updateSetting(value as number, false);
+                    },
+                    onChangeCommitted: (_, value) => {
+                        updateSetting(value as number, true);
+                    },
+                },
+            }}
+        />
+    );
+};

--- a/src/modules/reader/components/viewer/ReaderViewer.tsx
+++ b/src/modules/reader/components/viewer/ReaderViewer.tsx
@@ -408,6 +408,7 @@ const BaseReaderViewer = forwardRef(
                         width: '100%',
                         height: '100%',
                         overflow: 'auto',
+                        overscrollBehavior: 'contain',
                         flexWrap: 'nowrap',
                         // 滑动特效：页面跟随手指移动
                         transform: readingMode === ReadingMode.SINGLE_PAGE ? `translateX(${swipeOffset}px)` : 'none',

--- a/src/modules/reader/constants/ReaderSettings.constants.tsx
+++ b/src/modules/reader/constants/ReaderSettings.constants.tsx
@@ -72,6 +72,13 @@ export const PAGE_GAP = {
     step: 1,
 };
 
+export const SWIPE_PREVIEW_THRESHOLD = {
+    min: 10,
+    max: 50,
+    default: 30,
+    step: 5,
+};
+
 export const CUSTOM_FILTER = {
     brightness: {
         min: 5,
@@ -241,6 +248,7 @@ export const DEFAULT_READER_SETTINGS: IReaderSettings = {
     scrollAmount: ReaderScrollAmount.LARGE,
     shouldUseInfiniteScroll: true,
     shouldShowTransitionPage: true,
+    swipePreviewThreshold: SWIPE_PREVIEW_THRESHOLD.default,
 };
 
 export const READER_PROGRESS_BAR_POSITION_TO_PLACEMENT: Record<ProgressBarPosition, TooltipProps['placement']> = {

--- a/src/modules/reader/constants/ReaderSettings.constants.tsx
+++ b/src/modules/reader/constants/ReaderSettings.constants.tsx
@@ -73,10 +73,10 @@ export const PAGE_GAP = {
 };
 
 export const SWIPE_PREVIEW_THRESHOLD = {
-    min: 10,
+    min: 5,
     max: 50,
     default: 30,
-    step: 5,
+    step: 1,
 };
 
 export const CUSTOM_FILTER = {

--- a/src/modules/reader/hooks/useSwipeNavigate.ts
+++ b/src/modules/reader/hooks/useSwipeNavigate.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { ReadingDirection, ReadingMode } from '@/modules/reader/types/Reader.types.ts';
+import { ReaderControls } from '@/modules/reader/services/ReaderControls.ts';
+import { getNextPageIndex, getPage } from '@/modules/reader/utils/ReaderProgressBar.utils.tsx';
+import { ReaderStatePages } from '@/modules/reader/types/ReaderProgressBar.types.ts';
+
+interface UseSwipeNavigateProps {
+    readingMode: ReadingMode;
+    readingDirection: ReadingDirection;
+    swipePreviewThreshold: number;
+    currentPageIndex: number;
+    pages: ReaderStatePages['pages'];
+}
+
+const SWIPE_THRESHOLD = 30;
+const ANIMATION_DURATION = 200;
+
+export function useSwipeNavigate({
+    readingMode,
+    readingDirection,
+    swipePreviewThreshold,
+    currentPageIndex,
+    pages,
+}: UseSwipeNavigateProps) {
+    const [touchStart, setTouchStart] = useState<{ x: number; y: number; time: number } | null>(null);
+    const [isSwiping, setIsSwiping] = useState(false);
+    const [swipeOffset, setSwipeOffset] = useState(0);
+    const [previewDirection, setPreviewDirection] = useState<'next' | 'previous' | null>(null);
+    const [isTransitioning, setIsTransitioning] = useState(false);
+
+    const openPage = ReaderControls.useOpenPage();
+
+    const handleTouchStart = useCallback(
+        (e: React.TouchEvent) => {
+            if (e.touches.length === 1 && readingMode === ReadingMode.SINGLE_PAGE) {
+                const touch = e.touches[0];
+                setTouchStart({
+                    x: touch.clientX,
+                    y: touch.clientY,
+                    time: Date.now(),
+                });
+                setIsSwiping(false);
+                setSwipeOffset(0);
+                setPreviewDirection(null);
+            }
+        },
+        [readingMode],
+    );
+
+    const handleTouchMove = useCallback(
+        (e: React.TouchEvent) => {
+            if (!touchStart || e.touches.length !== 1 || readingMode !== ReadingMode.SINGLE_PAGE) {
+                return;
+            }
+
+            const touch = e.touches[0];
+            const deltaX = touch.clientX - touchStart.x;
+            const deltaY = Math.abs(touch.clientY - touchStart.y);
+            const absDeltaX = Math.abs(deltaX);
+
+            if (absDeltaX > deltaY && absDeltaX > SWIPE_THRESHOLD) {
+                setIsSwiping(true);
+                setSwipeOffset(deltaX);
+                const isLeftSwipe = deltaX < 0;
+                if (readingDirection === ReadingDirection.LTR) {
+                    setPreviewDirection(isLeftSwipe ? 'next' : 'previous');
+                } else {
+                    setPreviewDirection(isLeftSwipe ? 'previous' : 'next');
+                }
+            }
+        },
+        [touchStart, readingMode, readingDirection],
+    );
+
+    const handleTouchEnd = useCallback(
+        (e: React.TouchEvent) => {
+            if (!touchStart || readingMode !== ReadingMode.SINGLE_PAGE) {
+                setTouchStart(null);
+                setIsSwiping(false);
+                setSwipeOffset(0);
+                setPreviewDirection(null);
+                return;
+            }
+
+            const touch = e.changedTouches[0];
+            const deltaX = touch.clientX - touchStart.x;
+            const deltaY = Math.abs(touch.clientY - touchStart.y);
+            const distance = Math.abs(deltaX);
+            const triggerThreshold = window.innerWidth * (swipePreviewThreshold / 100);
+
+            if (distance > triggerThreshold && deltaY < 100) {
+                setIsTransitioning(true);
+                setTouchStart(null);
+                const targetOffset = deltaX > 0 ? window.innerWidth : -window.innerWidth;
+                setSwipeOffset(targetOffset);
+
+                setTimeout(() => {
+                    setSwipeOffset(0);
+                    const shouldGoNext = deltaX < 0;
+                    const direction = shouldGoNext ? 'next' : 'previous';
+                    openPage(direction);
+                    setPreviewDirection(null);
+                    setIsSwiping(false);
+                    setIsTransitioning(false);
+                }, ANIMATION_DURATION);
+                return;
+            }
+
+            setTouchStart(null);
+            setIsSwiping(false);
+            setSwipeOffset(0);
+            setPreviewDirection(null);
+        },
+        [touchStart, readingMode, readingDirection, openPage, swipePreviewThreshold],
+    );
+
+    const currentPage = useMemo(() => getPage(currentPageIndex, pages), [currentPageIndex, pages]);
+    const previewPageIndex = useMemo(() => {
+        if (!previewDirection) return null;
+        try {
+            return getNextPageIndex(previewDirection, currentPage.pagesIndex, pages);
+        } catch {
+            return null;
+        }
+    }, [previewDirection, currentPage.pagesIndex, pages]);
+
+    const previewPageUrl = useMemo(() => {
+        if (previewPageIndex === null) return null;
+        const previewPage = pages.find(
+            (page) => page.primary.index === previewPageIndex || page.secondary?.index === previewPageIndex,
+        );
+        return previewPage?.primary.index === previewPageIndex
+            ? previewPage.primary.url
+            : previewPage?.secondary?.url || null;
+    }, [previewPageIndex, pages]);
+
+    return {
+        isSwiping,
+        swipeOffset,
+        isTransitioning,
+        previewPageUrl,
+        previewDirection,
+        handleTouchStart,
+        handleTouchMove,
+        handleTouchEnd,
+    };
+}

--- a/src/modules/reader/hooks/useSwipeNavigate.ts
+++ b/src/modules/reader/hooks/useSwipeNavigate.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ReadingDirection, ReadingMode } from '@/modules/reader/types/Reader.types.ts';
 import { ReaderControls } from '@/modules/reader/services/ReaderControls.ts';
 import { getNextPageIndex, getPage } from '@/modules/reader/utils/ReaderProgressBar.utils.tsx';
@@ -37,6 +37,22 @@ export function useSwipeNavigate({
     const [isTransitioning, setIsTransitioning] = useState(false);
 
     const openPage = ReaderControls.useOpenPage();
+
+    useEffect(() => {
+        const handleTouchMove = (e: TouchEvent) => {
+            if (readingMode === ReadingMode.SINGLE_PAGE) {
+                e.preventDefault();
+            }
+        };
+
+        if (readingMode === ReadingMode.SINGLE_PAGE) {
+            document.addEventListener('touchmove', handleTouchMove, { passive: false });
+        }
+
+        return () => {
+            document.removeEventListener('touchmove', handleTouchMove);
+        };
+    }, [readingMode]);
 
     const handleTouchStart = useCallback(
         (e: React.TouchEvent) => {

--- a/src/modules/reader/types/Reader.types.ts
+++ b/src/modules/reader/types/Reader.types.ts
@@ -194,6 +194,10 @@ export interface IReaderSettingsManga {
         value: number;
         enabled: boolean;
     };
+    /**
+     * percentage of screen width for swipe preview threshold
+     */
+    swipePreviewThreshold: number;
 }
 
 export interface IReaderSettings extends IReaderSettingsGlobal, IReaderSettingsManga {}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,13 @@ export default defineConfig(() => ({
     },
     server: {
         port: 3000,
+        proxy: {
+            '/api': {
+                target: 'http://192.168.71.49:4567',
+                changeOrigin: true,
+                secure: false,
+            },
+        },
     },
     resolve: {
         alias: {


### PR DESCRIPTION
功能描述
在单页阅读模式下屏蔽上下滑动行为，防止意外的页面滚动。

主要改动
在 useSwipeNavigate.ts 中添加了触摸事件处理逻辑
只在单页模式下生效，不影响其他阅读模式
使用 preventDefault() 阻止默认滑动行为
添加了 overscrollBehavior: 'contain' 样式优化
测试
 单页模式下上下滑动被正确屏蔽
 左右滑动翻页功能正常
 其他阅读模式不受影响
提交信息
提交哈希: f423cafc
修改文件: 2个
新增代码: 18行